### PR TITLE
Add test for Execute

### DIFF
--- a/gsdb/Execute_test.go
+++ b/gsdb/Execute_test.go
@@ -28,11 +28,13 @@ func TestExecute(t *testing.T) {
 	dtadded DATETIME DEFAULT CURRENT_TIMESTAMP, 
 	status INTEGER NOT NULL
 	);`
-	_, _, err := DB.Execute("DROP TABLE IF EXISTS test;")
+
+	_, err := DB.dbConnection.Exec("DROP TABLE IF EXISTS test;")
 	if err != nil {
 		t.Fatalf("failed to execute drop table prior to tests: %v", err)
 	}
-	_, _, err = DB.Execute(tableCreate)
+	
+	_, err = DB.dbConnection.Exec(tableCreate)
 	if err != nil {
 		t.Fatalf("failed to execute tableCreate SQL prior to tests: %v", err)
 	}

--- a/gsdb/Execute_test.go
+++ b/gsdb/Execute_test.go
@@ -1,0 +1,62 @@
+package gsdb
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestExecute(t *testing.T) {
+	textHandler := slog.NewTextHandler(os.Stdout, nil)
+	l := slog.New(textHandler)
+	NewSQLite3("test.db", l, context.Background())
+
+	type TestPerson struct {
+		Id      int       `db:"column=id primarykey=yes table=Test"`
+		Name    string    `db:"column=name"`
+		Dtadded time.Time `db:"column=dtadded"`
+		Status  int       `db:"column=status"`
+		Ignored int       `db:"column=ignored omit=yes"`
+	}
+
+	tableCreate := `
+	CREATE TABLE IF NOT EXISTS test (
+	id INTEGER PRIMARY KEY AUTOINCREMENT, 
+	name TEXT NOT NULL, 
+	dtadded DATETIME DEFAULT CURRENT_TIMESTAMP, 
+	status INTEGER NOT NULL
+	);`
+	DB.Execute("DROP TABLE IF EXISTS test;")
+	DB.Execute(tableCreate)
+
+	tests := []struct {
+		name    string
+		entry   TestPerson
+		wantErr bool
+	}{
+		{
+			name:    "Execute an Insert success with all fields",
+			entry:   TestPerson{Name: "Ronald McDonald", Dtadded: time.Now().UTC(), Status: 1},
+		},
+		{
+			name:    "Execute an Insert with fields missing - current setup will populate missing fields with Go zero values",
+			entry:   TestPerson{Dtadded: time.Now().UTC()},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			insertSQL, err := DB.Insert(tc.entry)
+			if err != nil {
+				t.Fatalf("Execute() error: %v, wantErr %v", err, tc.wantErr)
+			}
+
+			_, _, err = DB.Execute(insertSQL)
+			if err != nil {
+				t.Fatalf("Execute() error: %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Small test for the Execute GSDB function

I'm sure there's some clean ups / effiency chances that can be done here, such as auto incrementing the test case IDs rather than manually setting them to +1 of the previous case. Let me know if you have any ideas
