### PR TITLE
Support readdefault=null for zero time.Time on insert/update/query

### DIFF
--- a/gsdb/Insert_test.go
+++ b/gsdb/Insert_test.go
@@ -35,3 +35,66 @@ func TestInsert(t *testing.T) {
 		t.Errorf("Expected: %s, got: %s", "INSERT INTO Test(`name`,`dtadded`,`status`) VALUES (X'54657374','2025-12-25 15:29:25',1);", sqlQuery)
 	}
 }
+
+func TestInsertReadDefaultNullMatrix(t *testing.T) {
+	type InsertPersonReadDefaultNull struct {
+		Id      int       `db:"column=id primarykey=yes table=Test"`
+		Name    string    `db:"column=name"`
+		Dtadded time.Time `db:"column=dtadded readdefault=null"`
+		Status  int       `db:"column=status"`
+	}
+
+	type InsertPersonNoDirective struct {
+		Id      int       `db:"column=id primarykey=yes table=Test"`
+		Name    string    `db:"column=name"`
+		Dtadded time.Time `db:"column=dtadded"`
+		Status  int       `db:"column=status"`
+	}
+
+	tests := []struct {
+		name     string
+		entry    any
+		expected string
+	}{
+		{
+			name: "readdefault null with zero time writes NULL",
+			entry: InsertPersonReadDefaultNull{
+				Name:    "Test",
+				Dtadded: time.Time{},
+				Status:  1,
+			},
+			expected: "INSERT INTO Test(name,dtadded,status) VALUES (X'54657374',NULL,1);",
+		},
+		{
+			name: "readdefault null with non-zero time writes timestamp",
+			entry: InsertPersonReadDefaultNull{
+				Name:    "Test",
+				Dtadded: time.Date(2025, time.December, 25, 15, 29, 25, 10, time.UTC),
+				Status:  1,
+			},
+			expected: "INSERT INTO Test(name,dtadded,status) VALUES (X'54657374','2025-12-25 15:29:25',1);",
+		},
+		{
+			name: "no directive with zero time writes zero timestamp",
+			entry: InsertPersonNoDirective{
+				Name:    "Test",
+				Dtadded: time.Time{},
+				Status:  1,
+			},
+			expected: "INSERT INTO Test(name,dtadded,status) VALUES (X'54657374','0001-01-01 00:00:00',1);",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sqlQuery, err := DB.Insert(tc.entry)
+			if err != nil {
+				t.Fatalf("failed to generate Insert SQL: %v", err)
+			}
+
+			if sqlQuery != tc.expected {
+				t.Errorf("Expected: %s, got: %s", tc.expected, sqlQuery)
+			}
+		})
+	}
+}

--- a/gsdb/QueryStruct.go
+++ b/gsdb/QueryStruct.go
@@ -68,6 +68,10 @@ func QueryStruct[T any](sql string, parameters ...any) ([]T, error) {
 					param = "zero"
 				}
 
+				if dbStructureMap["readdefault"] == "null" {
+					param = "zero"
+				}
+
 				reflect.ValueOf(&newStructRecord).Elem().FieldByName(structFieldName).Set(reflect.ValueOf(v.AsDate(param)))
 
 				// Add Blob Support.

--- a/gsdb/QueryStruct_test.go
+++ b/gsdb/QueryStruct_test.go
@@ -200,3 +200,252 @@ func TestQueryStruct(t *testing.T) {
 		})
 	}
 }
+
+func TestInsertWithReadDefaultNullWritesNullDate(t *testing.T) {
+	textHandler := slog.NewTextHandler(os.Stdout, nil)
+	l := slog.New(textHandler)
+	NewSQLite3("test.db", l, context.Background())
+
+	type TestPersonNullDateInsert struct {
+		Id      int       `db:"column=id primarykey=yes table=Test"`
+		Name    string    `db:"column=name"`
+		Dtadded time.Time `db:"column=dtadded readdefault=null"`
+		Status  int       `db:"column=status"`
+	}
+
+	tableCreate := `
+	CREATE TABLE IF NOT EXISTS test (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	name TEXT NOT NULL,
+	dtadded DATETIME DEFAULT CURRENT_TIMESTAMP,
+	status INTEGER NOT NULL
+	);`
+
+	_, err := DB.dbConnection.Exec("DROP TABLE IF EXISTS test;")
+	if err != nil {
+		t.Fatalf("failed to execute drop table prior to tests: %v", err)
+	}
+
+	_, err = DB.dbConnection.Exec(tableCreate)
+	if err != nil {
+		t.Fatalf("failed to execute tableCreate SQL prior to tests: %v", err)
+	}
+
+	entry := TestPersonNullDateInsert{
+		Name:   "Test",
+		Status: 1,
+	}
+
+	insertSQL, err := DB.Insert(entry)
+	if err != nil {
+		t.Fatalf("failed to generate Insert SQL: %v", err)
+	}
+
+	_, _, err = DB.Execute(insertSQL)
+	if err != nil {
+		t.Fatalf("failed to execute insert: %v", err)
+	}
+
+	records, err := DB.Query("SELECT dtadded FROM test WHERE id = 1")
+	if err != nil {
+		t.Fatalf("failed to query inserted row: %v", err)
+	}
+
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+
+	if records[0]["dtadded"].Value != nil {
+		t.Fatalf("expected dtadded to be NULL, got: %v", records[0]["dtadded"].Value)
+	}
+}
+
+func TestQuerySingleStructReadDefaultNullReturnsZeroTime(t *testing.T) {
+	textHandler := slog.NewTextHandler(os.Stdout, nil)
+	l := slog.New(textHandler)
+	NewSQLite3("test.db", l, context.Background())
+
+	type TestPersonNullDateQuery struct {
+		Id      int       `db:"column=id primarykey=yes table=Test"`
+		Name    string    `db:"column=name"`
+		Dtadded time.Time `db:"column=dtadded readdefault=null"`
+		Status  int       `db:"column=status"`
+	}
+
+	tableCreate := `
+	CREATE TABLE IF NOT EXISTS test (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	name TEXT NOT NULL,
+	dtadded DATETIME DEFAULT CURRENT_TIMESTAMP,
+	status INTEGER NOT NULL
+	);`
+
+	_, err := DB.dbConnection.Exec("DROP TABLE IF EXISTS test;")
+	if err != nil {
+		t.Fatalf("failed to execute drop table prior to tests: %v", err)
+	}
+
+	_, err = DB.dbConnection.Exec(tableCreate)
+	if err != nil {
+		t.Fatalf("failed to execute tableCreate SQL prior to tests: %v", err)
+	}
+
+	entry := TestPersonNullDateQuery{
+		Name:   "Test",
+		Status: 1,
+	}
+
+	insertSQL, err := DB.Insert(entry)
+	if err != nil {
+		t.Fatalf("failed to generate Insert SQL: %v", err)
+	}
+
+	lastInsertedID, _, err := DB.Execute(insertSQL)
+	if err != nil {
+		t.Fatalf("failed to execute insert: %v", err)
+	}
+
+	result, err := QuerySingleStruct[TestPersonNullDateQuery]("SELECT * FROM test WHERE id = ?", lastInsertedID)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+
+	if !result.Dtadded.IsZero() {
+		t.Fatalf("expected Dtadded to be zero time for SQL NULL with readdefault=null, got: %v", result.Dtadded)
+	}
+}
+
+func TestQuerySingleStructReadDefaultNullReturnsNonZeroTime(t *testing.T) {
+	textHandler := slog.NewTextHandler(os.Stdout, nil)
+	l := slog.New(textHandler)
+	NewSQLite3("test.db", l, context.Background())
+
+	type TestPersonNullDateQuery struct {
+		Id      int       `db:"column=id primarykey=yes table=Test"`
+		Name    string    `db:"column=name"`
+		Dtadded time.Time `db:"column=dtadded readdefault=null"`
+		Status  int       `db:"column=status"`
+	}
+
+	tableCreate := `
+	CREATE TABLE IF NOT EXISTS test (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	name TEXT NOT NULL,
+	dtadded DATETIME DEFAULT CURRENT_TIMESTAMP,
+	status INTEGER NOT NULL
+	);`
+
+	_, err := DB.dbConnection.Exec("DROP TABLE IF EXISTS test;")
+	if err != nil {
+		t.Fatalf("failed to execute drop table prior to tests: %v", err)
+	}
+
+	_, err = DB.dbConnection.Exec(tableCreate)
+	if err != nil {
+		t.Fatalf("failed to execute tableCreate SQL prior to tests: %v", err)
+	}
+
+	expected := time.Date(2025, time.December, 25, 15, 29, 25, 0, time.UTC)
+	entry := TestPersonNullDateQuery{
+		Name:    "Test",
+		Dtadded: expected,
+		Status:  1,
+	}
+
+	insertSQL, err := DB.Insert(entry)
+	if err != nil {
+		t.Fatalf("failed to generate Insert SQL: %v", err)
+	}
+
+	lastInsertedID, _, err := DB.Execute(insertSQL)
+	if err != nil {
+		t.Fatalf("failed to execute insert: %v", err)
+	}
+
+	result, err := QuerySingleStruct[TestPersonNullDateQuery]("SELECT * FROM test WHERE id = ?", lastInsertedID)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+
+	if !result.Dtadded.Equal(expected) {
+		t.Fatalf("expected Dtadded %v, got: %v", expected, result.Dtadded)
+	}
+}
+
+func TestQueryStructReadDefaultNullMixedRows(t *testing.T) {
+	textHandler := slog.NewTextHandler(os.Stdout, nil)
+	l := slog.New(textHandler)
+	NewSQLite3("test.db", l, context.Background())
+
+	type TestPersonNullDateQuery struct {
+		Id      int       `db:"column=id primarykey=yes table=Test"`
+		Name    string    `db:"column=name"`
+		Dtadded time.Time `db:"column=dtadded readdefault=null"`
+		Status  int       `db:"column=status"`
+	}
+
+	tableCreate := `
+	CREATE TABLE IF NOT EXISTS test (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	name TEXT NOT NULL,
+	dtadded DATETIME DEFAULT CURRENT_TIMESTAMP,
+	status INTEGER NOT NULL
+	);`
+
+	_, err := DB.dbConnection.Exec("DROP TABLE IF EXISTS test;")
+	if err != nil {
+		t.Fatalf("failed to execute drop table prior to tests: %v", err)
+	}
+
+	_, err = DB.dbConnection.Exec(tableCreate)
+	if err != nil {
+		t.Fatalf("failed to execute tableCreate SQL prior to tests: %v", err)
+	}
+
+	first := TestPersonNullDateQuery{
+		Name:   "Test",
+		Status: 1,
+	}
+
+	secondExpected := time.Date(2025, time.December, 25, 15, 29, 25, 0, time.UTC)
+	second := TestPersonNullDateQuery{
+		Name:    "Test",
+		Dtadded: secondExpected,
+		Status:  2,
+	}
+
+	insertSQL, err := DB.Insert(first)
+	if err != nil {
+		t.Fatalf("failed to generate first Insert SQL: %v", err)
+	}
+	_, _, err = DB.Execute(insertSQL)
+	if err != nil {
+		t.Fatalf("failed to execute first insert: %v", err)
+	}
+
+	insertSQL, err = DB.Insert(second)
+	if err != nil {
+		t.Fatalf("failed to generate second Insert SQL: %v", err)
+	}
+	_, _, err = DB.Execute(insertSQL)
+	if err != nil {
+		t.Fatalf("failed to execute second insert: %v", err)
+	}
+
+	results, err := QueryStruct[TestPersonNullDateQuery]("SELECT * FROM test ORDER BY id ASC")
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(results))
+	}
+
+	if !results[0].Dtadded.IsZero() {
+		t.Fatalf("expected first Dtadded to be zero time, got: %v", results[0].Dtadded)
+	}
+
+	if !results[1].Dtadded.Equal(secondExpected) {
+		t.Fatalf("expected second Dtadded %v, got: %v", secondExpected, results[1].Dtadded)
+	}
+}

--- a/gsdb/Update.go
+++ b/gsdb/Update.go
@@ -53,7 +53,14 @@ func (db *Database) Update(dbStructure any) (string, error) {
 				case "bool":
 					buildsql = buildsql + fmt.Sprintf("%v", value) + ","
 				case "Time":
-					buildsql = buildsql + fmt.Sprintf("'%s'", value.(time.Time).Format("2006-01-02 15:04:05")) + ","
+					timeValue := value.(time.Time)
+					// If the model uses readdefault=null and is zero time,
+					// persist SQL NULL instead of a zero-date timestamp.
+					if dbStructureMap["readdefault"] == "null" && timeValue.IsZero() {
+						buildsql = buildsql + "NULL,"
+					} else {
+						buildsql = buildsql + fmt.Sprintf("'%s'", timeValue.Format("2006-01-02 15:04:05")) + ","
+					}
 				default:
 					db.Logger.With("type", field.Type.Name()).With("value", value).Error("type error")
 					buildsql = buildsql + "'" + value.(string) + "',"

--- a/gsdb/Update_test.go
+++ b/gsdb/Update_test.go
@@ -21,6 +21,18 @@ type UpdatePersonTime struct {
 	Dtadded time.Time `db:"column=dtadded"`
 }
 
+type UpdatePersonTimeNull struct {
+	Id      int       `db:"column=id primarykey=yes table=Users"`
+	Name    string    `db:"column=name"`
+	Dtadded time.Time `db:"column=dtadded readdefault=null"`
+}
+
+type UpdatePersonTimeNoDirective struct {
+	Id      int       `db:"column=id primarykey=yes table=Users"`
+	Name    string    `db:"column=name"`
+	Dtadded time.Time `db:"column=dtadded"`
+}
+
 func generateUpdatePerson[StatusType uint | uint8 | uint16 | uint32 | uint64 | int | int8 | int16 | int32 | int64 | float32 | float64 | string | bool](value StatusType) UpdatePerson[StatusType] {
 	return UpdatePerson[StatusType]{
 		0, "Test", time.Now(), value,
@@ -30,6 +42,24 @@ func generateUpdatePerson[StatusType uint | uint8 | uint16 | uint32 | uint64 | i
 func generateUpdatePersonTime(id int) UpdatePersonTime {
 	return UpdatePersonTime{
 		id, "Test", time.Date(2024, time.December, 7, 15, 29, 25, 10, time.UTC),
+	}
+}
+
+func generateUpdatePersonTimeNull(id int) UpdatePersonTimeNull {
+	return UpdatePersonTimeNull{
+		id, "Test", time.Time{},
+	}
+}
+
+func generateUpdatePersonTimeNullWithValue(id int, dateValue time.Time) UpdatePersonTimeNull {
+	return UpdatePersonTimeNull{
+		id, "Test", dateValue,
+	}
+}
+
+func generateUpdatePersonTimeNoDirective(id int) UpdatePersonTimeNoDirective {
+	return UpdatePersonTimeNoDirective{
+		id, "Test", time.Time{},
 	}
 }
 
@@ -51,6 +81,11 @@ func testUpdateStringErrorValueHelper(t *testing.T, sql string, err error) {
 func testUpdateTimeErrorValueHelper(t *testing.T, sql string, err error) {
 	assert.NoError(t, err)
 	assert.Equal(t, "UPDATE Users SET name=X'54657374',dtadded='2024-12-07 15:29:25' WHERE id=0;", sql)
+}
+
+func testUpdateTimeNullErrorValueHelper(t *testing.T, sql string, err error) {
+	assert.NoError(t, err)
+	assert.Equal(t, "UPDATE Users SET name=X'54657374',dtadded=NULL WHERE id=0;", sql)
 }
 
 func TestUpdate(t *testing.T) {
@@ -88,6 +123,9 @@ func TestUpdate(t *testing.T) {
 
 	sql, err = DB.Update(generateUpdatePersonTime(0))
 	testUpdateTimeErrorValueHelper(t, sql, err)
+
+	sql, err = DB.Update(generateUpdatePersonTimeNull(0))
+	testUpdateTimeNullErrorValueHelper(t, sql, err)
 }
 
 func TestNoColumnNameUpdate(t *testing.T) {
@@ -122,6 +160,40 @@ func TestNoColumnNameUpdate(t *testing.T) {
 	sql, err = DB.Update(testTypeEntry3)
 	assert.EqualError(t, err, "no column name specified for field Name")
 	assert.Empty(t, sql)
+}
+
+func TestUpdateReadDefaultNullMatrix(t *testing.T) {
+	New("", nil, context.Background())
+
+	tests := []struct {
+		name     string
+		entry    any
+		expected string
+	}{
+		{
+			name:     "readdefault null with zero time writes NULL",
+			entry:    generateUpdatePersonTimeNull(1),
+			expected: "UPDATE Users SET name=X'54657374',dtadded=NULL WHERE id=1;",
+		},
+		{
+			name:     "readdefault null with non-zero time writes timestamp",
+			entry:    generateUpdatePersonTimeNullWithValue(2, time.Date(2024, time.December, 7, 15, 29, 25, 10, time.UTC)),
+			expected: "UPDATE Users SET name=X'54657374',dtadded='2024-12-07 15:29:25' WHERE id=2;",
+		},
+		{
+			name:     "no directive with zero time writes zero timestamp",
+			entry:    generateUpdatePersonTimeNoDirective(3),
+			expected: "UPDATE Users SET name=X'54657374',dtadded='0001-01-01 00:00:00' WHERE id=3;",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sql, err := DB.Update(tc.entry)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, sql)
+		})
+	}
 }
 
 func TestNoTableNameUpdate(t *testing.T) {

--- a/gsdb/common.go
+++ b/gsdb/common.go
@@ -67,7 +67,14 @@ func generateValuesSql(dbStructure any, t reflect.Type) (string, error) {
 				case "bool":
 					sb.WriteString(fmt.Sprintf("%v,", value))
 				case "Time":
-					sb.WriteString(fmt.Sprintf("'%s',", value.(time.Time).Format("2006-01-02 15:04:05")))
+					timeValue := value.(time.Time)
+					// If the model uses readdefault=null and is zero time,
+					// persist SQL NULL instead of a zero-date timestamp.
+					if dbStructureMap["readdefault"] == "null" && timeValue.IsZero() {
+						sb.WriteString("NULL,")
+					} else {
+						sb.WriteString(fmt.Sprintf("'%s',", timeValue.Format("2006-01-02 15:04:05")))
+					}
 				default:
 					l.With("type", field.Type.Name()).With("value", value).Error("type error")
 					sb.WriteString(fmt.Sprintf(`'%s',`, value.(string)))


### PR DESCRIPTION
* Adds support for readdefault=null on [time.Time](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) fields.
* With this directive, zero time values are saved as SQL NULL in Insert/Update.
* On reads, DB NULL values map back to zero [time.Time](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
* Existing behavior is unchanged when the directive is not used.
* Adds/updates tests for Insert, Update, and Query coverage.